### PR TITLE
Add natdb_datasets function

### DIFF
--- a/R/datasets.R
+++ b/R/datasets.R
@@ -1,0 +1,19 @@
+#' @name natdb_datasets
+#' @title Get vector of the IDs for all datasets available within NATDB
+#' @description Returns a vector of all IDs for the datasets that NATDB can download. This can be used to identify particular datasets you wish to download using \code{\link{natdb}}.
+#' @keywords datasets
+#' @usage natdb_datasets()
+#' @seealso citations natdb
+#' @return Vector of dataset IDs
+#' @author Will Pearse; Matthew Helmus
+#' #@examples
+#' \dontrun{
+#' datasets <- natdb_datasets()
+#' data <- natdb(datasets = datasets[1:2])
+#' }
+#' 
+#' @export
+natdb_datasets <- function(){
+    datasets <- Filter(Negate(is.function), ls(pattern="^\\.[a-z]*\\.[0-9]+", name="package:natdb", all.names=TRUE))
+  return(datasets)
+} 


### PR DESCRIPTION
If users want to just download some of the data sets (and it is easier to debug functions). Here is a short function to get the list of dataset IDs (i.e., function names) of all datasets that natdb can download. I basically just copied it from the natdb() code.